### PR TITLE
use truncate for telemetry log file

### DIFF
--- a/src/utils/telemetry_logger.cpp
+++ b/src/utils/telemetry_logger.cpp
@@ -26,7 +26,7 @@ void TelemetryLogger::init(bool enabled, const std::string &path) {
 		return;
 	}
 
-	out_.open(path, std::ios::out | std::ios::app);
+	out_.open(path, std::ios::out | std::ios::trunc);
 	if (!out_) {
 		std::cerr << "[TelemetryLogger] Failed to open telemetry file '" << path << "' — disabling telemetry" << std::endl;
 		return;


### PR DESCRIPTION
@pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing 