### PR TITLE
Add center/pose results to telemetry

### DIFF
--- a/src/stages/pose_stage.hpp
+++ b/src/stages/pose_stage.hpp
@@ -30,6 +30,7 @@ public:
         // Always emplace pose_result and set has_pose so the frame continues to output
         auto& pr = ctx->pose_result.emplace();
         pr.valid  = false;
+        pr.confidence = 0.f;
         ctx->flags.has_pose        = true;
         ctx->flags.skip_processing = false;
 
@@ -48,6 +49,12 @@ public:
             Point2f center = smoothed_initialized_
                 ? stabilizedCenter(ctx)
                 : Point2f(ctx->frame.cols / 2.f, ctx->frame.rows / 2.f);
+
+            // In passive mode, we still output a best-effort center each frame.
+            pr.center = center;
+            pr.valid = smoothed_initialized_; // "valid" means we have a tracked center.
+            pr.confidence = 0.f;
+
             crop(ctx, center);
             return;
         }

--- a/src/utils/telemetry_logger.cpp
+++ b/src/utils/telemetry_logger.cpp
@@ -73,6 +73,17 @@ void TelemetryLogger::log_frame(const FrameContext &ctx) {
 	out_ << "\"status\":\"" << status << "\",";
 	out_ << "\"dropped\":" << (ctx.flags.drop_frame ? "true" : "false") << ',';
 
+	// Pose center (when available)
+	if (ctx.pose_result.has_value()) {
+		out_ << "\"pose\":{";
+		out_ << "\"valid\":" << (ctx.pose_result->valid ? "true" : "false") << ',';
+		out_ << "\"confidence\":" << ctx.pose_result->confidence << ',';
+		out_ << "\"center\":{";
+		out_ << "\"x\":" << ctx.pose_result->center.x << ',';
+		out_ << "\"y\":" << ctx.pose_result->center.y;
+		out_ << "}} ,";
+	}
+
 	out_ << "\"stages\":{";
 	bool first_stage = true;
 	for (const auto &kv : ctx.telemetry.per_stage) {
@@ -101,5 +112,4 @@ void TelemetryLogger::log_frame(const FrameContext &ctx) {
 	out_ << "}}\n";
 	out_.flush();
 }
-
 


### PR DESCRIPTION
@pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing @pSlessing 